### PR TITLE
fix(git): replace rev-list with abbrev

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,7 @@ if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
 else
     # For the base SHA for main builds we use the latest matching tag as a marker for the last commit which was successfully built.
     # We use 2> /dev/null to swallow any direct errors from the command itself so we can provide more useful messaging
-    TAG=$(git describe --tags `git rev-list --tags --max-count=1` --match="$INPUTS_TAG_MATCH_PATTERN" 2> /dev/null)
+    TAG=$(git describe --tags --abbrev=0 --match="$INPUTS_TAG_MATCH_PATTERN" 2> /dev/null)
 
     if [ -z $TAG ]; then
         if [ $INPUTS_ERROR_ON_NO_MATCHING_TAGS = "true" ]; then


### PR DESCRIPTION
The `git rev-list` searches through all the branches, so it might pick up `tag` from another branch leading to invalid SHA.