### PR TITLE
Added output to indicate when no previous build was found on this branch

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6400,6 +6400,7 @@ let BASE_SHA;
         process.stdout.write(`NOTE: You can instead make this a hard error by settting 'error-on-no-successful-workflow' on the action in your workflow.\n`);
 
         BASE_SHA = execSync(`git rev-parse HEAD~1`, { encoding: 'utf-8' });
+        core.setOutput('noPreviousBuild', 'true');
       }
     } else {
       process.stdout.write('\n');

--- a/find-successful-workflow.js
+++ b/find-successful-workflow.js
@@ -36,6 +36,7 @@ let BASE_SHA;
         process.stdout.write(`NOTE: You can instead make this a hard error by settting 'error-on-no-successful-workflow' on the action in your workflow.\n`);
 
         BASE_SHA = execSync(`git rev-parse HEAD~1`, { encoding: 'utf-8' });
+        core.setOutput('noPreviousBuild', 'true');
       }
     } else {
       process.stdout.write('\n');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.1.3",
+  "version": "2.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "2.1.3",
+  "version": "2.1.4",
   "license": "MIT",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action",
   "scripts": {


### PR DESCRIPTION
When working with NX, I want to be able to build everything to a new namespace if there has never been a build on that branch before.

I should already be able to do this using:
```
main-branch-name: ${{ github.ref_name }}
```
However I only have the option to error if there have been no builds on this branch before.

By outputting this information if none are found, I can then use a conditional later on in my workflow to build everything (or specific projects). NX will then deploy what I want to the new namespace.

Open to input as I'm not sure if what I've done here is best practise, for example we don't set the output to false anywhere else for example. I'm unfamiliar with custom github actions