### PR TITLE
Add missing possible output to action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ outputs:
   head:
     description: The value intended for use with --head or NX_HEAD in all subsequent `nx affected` commands within the current workflow
     value: ${{ steps.setSHAs.outputs.head }}
+  noPreviousBuild:
+    description: "Used to check if a previous run was found in order to perform additional logic later on in your workflow, the only possible values is the string 'true', otherwise it won't be set"
+    value: ${{ steps.setSHAs.outputs.noPreviousBuild }}
 
 runs:
   using: "composite"


### PR DESCRIPTION
This output was added to the code a while ago via PR #16 , however I didn't realise it should probably be added to the actual action.yml in order to be consistent with the others

Not sure if this should also maybe be added to the readme, perhaps with example implementations like using a simple if to decide if to run `nx affected` or `nx run-many`, or something more advanced like using it with [this action](https://github.com/marketplace/actions/conditional-value-for-github-action) to use a hardcoded sha instead of the HEAD~1 that it defaults to.