### PR TITLE
fix: remove branch filter in runs search when event is of type release

### DIFF
--- a/find-successful-workflow.js
+++ b/find-successful-workflow.js
@@ -99,7 +99,7 @@ async function findSuccessfulCommit(workflow_id, run_id, owner, repo, branch, la
     owner,
     repo,
     // on release workflow runs do not have branch property
-    branch: lastSuccessfulEvent === "release" ? undefined : branch,
+    branch: lastSuccessfulEvent === 'release' ? undefined : branch,
     workflow_id,
     event: lastSuccessfulEvent,
     status: 'success'

--- a/find-successful-workflow.js
+++ b/find-successful-workflow.js
@@ -98,7 +98,8 @@ async function findSuccessfulCommit(workflow_id, run_id, owner, repo, branch, la
   const shas = await octokit.request(`GET /repos/${owner}/${repo}/actions/workflows/${workflow_id}/runs`, {
     owner,
     repo,
-    branch,
+    // on release workflow runs do not have branch property
+    branch: lastSuccessfulEvent === "release" ? undefined : branch,
     workflow_id,
     event: lastSuccessfulEvent,
     status: 'success'


### PR DESCRIPTION
Solves https://github.com/nrwl/nx-set-shas/issues/19

On release workflow runs seem to not have any branch property associated with them, thus the filter on branch creates a bug (no run is found):

![image](https://user-images.githubusercontent.com/38014240/173191447-324de471-dae6-4f7a-88ee-288ff25a6009.png)


![image](https://user-images.githubusercontent.com/38014240/173191437-71edfbdc-804c-45cf-b4bd-fa96ed4a7017.png)