### PR TITLE
refactor: escape user input to prevent script injection

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,8 +36,10 @@ runs:
   steps:
     - name: Set base and head SHAs used for nx affected
       id: setSHAs
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       shell: bash
-      run: node $GITHUB_ACTION_PATH/dist/index.js ${{ github.token }}
+      run: node $GITHUB_ACTION_PATH/dist/index.js
 
     - name: Log base and head SHAs used for nx affected
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
     - name: Set base and head SHAs used for nx affected
       id: setSHAs
       shell: bash
-      run: node $GITHUB_ACTION_PATH/dist/index.js ${{ github.token }} ${{ inputs.main-branch-name }} ${{ inputs.error-on-no-successful-workflow }} ${{ inputs.last-successful-event }} ${{ inputs.working-directory }} ${{ inputs.workflow-id }}
+      run: node $GITHUB_ACTION_PATH/dist/index.js ${{ github.token }}
 
     - name: Log base and head SHAs used for nx affected
       shell: bash

--- a/dist/index.js
+++ b/dist/index.js
@@ -62798,7 +62798,6 @@ const { execSync } = __nccwpck_require__(3129);
 const { existsSync } = __nccwpck_require__(5747);
 
 const { runId, repo: { repo, owner }, eventName } = github.context;
-process.env.GITHUB_TOKEN = process.argv[2];
 const mainBranchName = core.getInput('main-branch-name');
 const errorOnNoSuccessfulWorkflow = core.getInput('error-on-no-successful-workflow');
 const lastSuccessfulEvent = core.getInput('last-successful-event');

--- a/dist/index.js
+++ b/dist/index.js
@@ -62799,11 +62799,11 @@ const { existsSync } = __nccwpck_require__(5747);
 
 const { runId, repo: { repo, owner }, eventName } = github.context;
 process.env.GITHUB_TOKEN = process.argv[2];
-const mainBranchName = process.argv[3];
-const errorOnNoSuccessfulWorkflow = process.argv[4];
-const lastSuccessfulEvent = process.argv[5];
-const workingDirectory = process.argv[6];
-const workflowId = process.argv[7];
+const mainBranchName = core.getInput('main-branch-name');
+const errorOnNoSuccessfulWorkflow = core.getInput('error-on-no-successful-workflow');
+const lastSuccessfulEvent = core.getInput('last-successful-event');
+const workingDirectory = core.getInput('working-directory');
+const workflowId = core.getInput('workflow-id');
 const defaultWorkingDirectory = '.';
 
 let BASE_SHA;
@@ -62820,7 +62820,7 @@ let BASE_SHA;
   const HEAD_SHA = execSync(`git rev-parse HEAD`, { encoding: 'utf-8' });
 
   if (eventName === 'pull_request') {
-    BASE_SHA = execSync(`git merge-base origin/${mainBranchName} HEAD`, { encoding: 'utf-8' });
+    BASE_SHA = execSync(`git merge-base origin/"${mainBranchName}" HEAD`, { encoding: 'utf-8' });
   } else {
     try {
       BASE_SHA = await findSuccessfulCommit(workflowId, runId, owner, repo, mainBranchName, lastSuccessfulEvent);

--- a/dist/index.js
+++ b/dist/index.js
@@ -62811,8 +62811,8 @@ let BASE_SHA;
     if (existsSync(workingDirectory)) {
       process.chdir(workingDirectory);
     } else {
-      process.stdout.write('\n');
-      process.stdout.write(`WARNING: Working directory '${workingDirectory}' doesn't exist.\n`);
+      core.warning('\n');
+      core.warning(`WARNING: Working directory '${workingDirectory}' doesn't exist.\n`);
     }
   }
 
@@ -62833,19 +62833,19 @@ let BASE_SHA;
         reportFailure(mainBranchName);
         return;
       } else {
-        process.stdout.write('\n');
-        process.stdout.write(`WARNING: Unable to find a successful workflow run on 'origin/${mainBranchName}'\n`);
-        process.stdout.write(`We are therefore defaulting to use HEAD~1 on 'origin/${mainBranchName}'\n`);
-        process.stdout.write('\n');
-        process.stdout.write(`NOTE: You can instead make this a hard error by setting 'error-on-no-successful-workflow' on the action in your workflow.\n`);
+        core.warning('\n');
+        core.warning(`WARNING: Unable to find a successful workflow run on 'origin/${mainBranchName}'\n`);
+        core.warning(`We are therefore defaulting to use HEAD~1 on 'origin/${mainBranchName}'\n`);
+        core.warning('\n');
+        core.warning(`NOTE: You can instead make this a hard error by setting 'error-on-no-successful-workflow' on the action in your workflow.\n`);
 
         BASE_SHA = execSync(`git rev-parse HEAD~1`, { encoding: 'utf-8' });
         core.setOutput('noPreviousBuild', 'true');
       }
     } else {
-      process.stdout.write('\n');
-      process.stdout.write(`Found the last successful workflow run on 'origin/${mainBranchName}'\n`);
-      process.stdout.write(`Commit: ${BASE_SHA}\n`);
+      core.info('\n');
+      core.info(`Found the last successful workflow run on 'origin/${mainBranchName}'\n`);
+      core.info(`Commit: ${BASE_SHA}\n`);
     }
   }
 
@@ -62882,8 +62882,8 @@ async function findSuccessfulCommit(workflow_id, run_id, owner, repo, branch, la
       branch,
       run_id
     }).then(({ data: { workflow_id } }) => workflow_id);
-    process.stdout.write('\n');
-    process.stdout.write(`Workflow Id not provided. Using workflow '${workflow_id}'\n`);
+    core.info('\n');
+    core.info(`Workflow Id not provided. Using workflow '${workflow_id}'\n`);
   }
   // fetch all workflow runs on a given repo/branch/workflow with push and success
   const shas = await octokit.request(`GET /repos/${owner}/${repo}/actions/workflows/${workflow_id}/runs`, {

--- a/find-successful-workflow.js
+++ b/find-successful-workflow.js
@@ -18,8 +18,8 @@ let BASE_SHA;
     if (existsSync(workingDirectory)) {
       process.chdir(workingDirectory);
     } else {
-      process.stdout.write('\n');
-      process.stdout.write(`WARNING: Working directory '${workingDirectory}' doesn't exist.\n`);
+      core.warning('\n');
+      core.warning(`WARNING: Working directory '${workingDirectory}' doesn't exist.\n`);
     }
   }
 
@@ -40,19 +40,19 @@ let BASE_SHA;
         reportFailure(mainBranchName);
         return;
       } else {
-        process.stdout.write('\n');
-        process.stdout.write(`WARNING: Unable to find a successful workflow run on 'origin/${mainBranchName}'\n`);
-        process.stdout.write(`We are therefore defaulting to use HEAD~1 on 'origin/${mainBranchName}'\n`);
-        process.stdout.write('\n');
-        process.stdout.write(`NOTE: You can instead make this a hard error by setting 'error-on-no-successful-workflow' on the action in your workflow.\n`);
+        core.warning('\n');
+        core.warning(`WARNING: Unable to find a successful workflow run on 'origin/${mainBranchName}'\n`);
+        core.warning(`We are therefore defaulting to use HEAD~1 on 'origin/${mainBranchName}'\n`);
+        core.warning('\n');
+        core.warning(`NOTE: You can instead make this a hard error by setting 'error-on-no-successful-workflow' on the action in your workflow.\n`);
 
         BASE_SHA = execSync(`git rev-parse HEAD~1`, { encoding: 'utf-8' });
         core.setOutput('noPreviousBuild', 'true');
       }
     } else {
-      process.stdout.write('\n');
-      process.stdout.write(`Found the last successful workflow run on 'origin/${mainBranchName}'\n`);
-      process.stdout.write(`Commit: ${BASE_SHA}\n`);
+      core.info('\n');
+      core.info(`Found the last successful workflow run on 'origin/${mainBranchName}'\n`);
+      core.info(`Commit: ${BASE_SHA}\n`);
     }
   }
 
@@ -89,8 +89,8 @@ async function findSuccessfulCommit(workflow_id, run_id, owner, repo, branch, la
       branch,
       run_id
     }).then(({ data: { workflow_id } }) => workflow_id);
-    process.stdout.write('\n');
-    process.stdout.write(`Workflow Id not provided. Using workflow '${workflow_id}'\n`);
+    core.info('\n');
+    core.info(`Workflow Id not provided. Using workflow '${workflow_id}'\n`);
   }
   // fetch all workflow runs on a given repo/branch/workflow with push and success
   const shas = await octokit.request(`GET /repos/${owner}/${repo}/actions/workflows/${workflow_id}/runs`, {

--- a/find-successful-workflow.js
+++ b/find-successful-workflow.js
@@ -6,11 +6,11 @@ const { existsSync } = require('fs');
 
 const { runId, repo: { repo, owner }, eventName } = github.context;
 process.env.GITHUB_TOKEN = process.argv[2];
-const mainBranchName = process.argv[3];
-const errorOnNoSuccessfulWorkflow = process.argv[4];
-const lastSuccessfulEvent = process.argv[5];
-const workingDirectory = process.argv[6];
-const workflowId = process.argv[7];
+const mainBranchName = core.getInput('main-branch-name');
+const errorOnNoSuccessfulWorkflow = core.getInput('error-on-no-successful-workflow');
+const lastSuccessfulEvent = core.getInput('last-successful-event');
+const workingDirectory = core.getInput('working-directory');
+const workflowId = core.getInput('workflow-id');
 const defaultWorkingDirectory = '.';
 
 let BASE_SHA;
@@ -27,7 +27,7 @@ let BASE_SHA;
   const HEAD_SHA = execSync(`git rev-parse HEAD`, { encoding: 'utf-8' });
 
   if (eventName === 'pull_request') {
-    BASE_SHA = execSync(`git merge-base origin/${mainBranchName} HEAD`, { encoding: 'utf-8' });
+    BASE_SHA = execSync(`git merge-base origin/"${mainBranchName}" HEAD`, { encoding: 'utf-8' });
   } else {
     try {
       BASE_SHA = await findSuccessfulCommit(workflowId, runId, owner, repo, mainBranchName, lastSuccessfulEvent);

--- a/find-successful-workflow.js
+++ b/find-successful-workflow.js
@@ -5,7 +5,6 @@ const { execSync } = require('child_process');
 const { existsSync } = require('fs');
 
 const { runId, repo: { repo, owner }, eventName } = github.context;
-process.env.GITHUB_TOKEN = process.argv[2];
 const mainBranchName = core.getInput('main-branch-name');
 const errorOnNoSuccessfulWorkflow = core.getInput('error-on-no-successful-workflow');
 const lastSuccessfulEvent = core.getInput('last-successful-event');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "2.2.4",
+  "version": "2.2.6",
   "license": "MIT",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "2.2.5",
+  "version": "2.2.4",
   "license": "MIT",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action",
   "scripts": {


### PR DESCRIPTION
# Security hardening
- Use the core API for reading input parameters to remove dependency on argument order in the Node.js script
- Escape user inputs in shell commands to prevent script injections
- Pass the GitHub token as an environment variable instead of a command line argument to decrease the risk of token leaks
- Use the core API for logging to decrease the risk of secret leaks