### PR TITLE
fix: forward input parameters to Node.js script as environment variables

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,12 @@ runs:
       id: setSHAs
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        # Input parameters are not automatically set as environment variables in composite actions
+        INPUT_MAIN_BRANCH_NAME: ${{ inputs.main-branch-name }}
+        INPUT_ERROR_ON_NO_SUCCESSFUL_WORKFLOW: ${{ inputs.error-on-no-successful-workflow }}
+        INPUT_LAST_SUCCESSFUL_EVENT: ${{ inputs.last-successful-event }}
+        INPUT_WORKING_DIRECTORY: ${{ inputs.working-directory }}
+        INPUT_WORKFLOW_ID: ${{ inputs.workflow-id }}
       shell: bash
       run: node $GITHUB_ACTION_PATH/dist/index.js
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "2.2.6",
+  "version": "2.2.7",
   "license": "MIT",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action",
   "scripts": {


### PR DESCRIPTION
Manually forward input parameters to the Node.js script as environment variables because [input parameters are not automatically forwarded as environment variables in composite actions](https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#inputs).

Fixes #59