### PR TITLE
fix: support pull_request_target trigger events

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13734,7 +13734,7 @@ let BASE_SHA;
 
   const HEAD_SHA = execSync(`git rev-parse HEAD`, { encoding: 'utf-8' });
 
-  if (eventName === 'pull_request') {
+  if (eventName === 'pull_request' || eventName === 'pull_request_target') {
     BASE_SHA = execSync(`git merge-base origin/${mainBranchName} HEAD`, { encoding: 'utf-8' });
   } else {
     try {

--- a/find-successful-workflow.js
+++ b/find-successful-workflow.js
@@ -26,7 +26,7 @@ let BASE_SHA;
 
   const HEAD_SHA = execSync(`git rev-parse HEAD`, { encoding: 'utf-8' });
 
-  if (eventName === 'pull_request') {
+  if (eventName === 'pull_request' || eventName === 'pull_request_target') {
     BASE_SHA = execSync(`git merge-base origin/${mainBranchName} HEAD`, { encoding: 'utf-8' });
   } else {
     try {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "3.0.2",
+  "version": "3.0.3",
   "license": "MIT",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action",
   "scripts": {


### PR DESCRIPTION
Close #81 

Currently, `BASE_SHA` and `HEAD_SHA` are wrongly evaluated when the action is used in workflow triggered by `pull_request_target` causing invalid results.

This PR add support for `pull_request_target` and it match the same logic used for `pull_request` events where:
- `BASE_SHA` is the commit in the main branch (or the branch configured) from which the PR branch originated
- `HEAD_SHA` is the `HEAD-commit-of-PR-branch`