### PR TITLE
fix: support pull_request events that are already merged

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13734,7 +13734,7 @@ let BASE_SHA;
 
   const HEAD_SHA = execSync(`git rev-parse HEAD`, { encoding: 'utf-8' });
 
-  if (eventName === 'pull_request') {
+  if (eventName === 'pull_request' && !github.context.payload.pull_request.merged) {
     BASE_SHA = execSync(`git merge-base origin/${mainBranchName} HEAD`, { encoding: 'utf-8' });
   } else {
     try {

--- a/find-successful-workflow.js
+++ b/find-successful-workflow.js
@@ -26,7 +26,7 @@ let BASE_SHA;
 
   const HEAD_SHA = execSync(`git rev-parse HEAD`, { encoding: 'utf-8' });
 
-  if (eventName === 'pull_request') {
+  if (eventName === 'pull_request' && !github.context.payload.pull_request.merged) {
     BASE_SHA = execSync(`git merge-base origin/${mainBranchName} HEAD`, { encoding: 'utf-8' });
   } else {
     try {


### PR DESCRIPTION
Fixes https://github.com/nrwl/nx-set-shas/issues/83

When a workflow is running with the `pull_request` event, and the change is already merged on the main branch, the BASE SHA is incorrectly recovered with `git merge-base`. This is because the best common ancestor to the current commit is itself, so you always end up with the same commit SHA on BASE and HEAD.

This propose following the regular path to fetch the BASE SHA if it is a `pull_request` event and its payload indicates it has already been merged.