### PR TITLE
feat: add support for merge queues (merge_group events)

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13943,7 +13943,7 @@ let BASE_SHA;
   const headResult = spawnSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf-8' });
   const HEAD_SHA = headResult.stdout;
 
-  if (['pull_request', 'pull_request_target', 'merge_queue'].includes(eventName) && !github.context.payload.pull_request.merged) {
+  if (['pull_request', 'pull_request_target', 'merge_group'].includes(eventName) && !github.context.payload.pull_request.merged) {
     try {
       const mergeBaseRef = await findMergeBaseRef();
       const baseResult = spawnSync('git', ['merge-base', `origin/${mainBranchName}`, mergeBaseRef], { encoding: 'utf-8' });
@@ -14036,7 +14036,7 @@ async function findSuccessfulCommit(workflow_id, run_id, owner, repo, branch, la
 }
 
 async function findMergeBaseRef() {
-  if (eventName == 'merge_queue') {
+  if (eventName == 'merge_group') {
     return await findMergeQueueBranch(owner, repo, mainBranchName);
   } else {
     return 'HEAD'

--- a/dist/index.js
+++ b/dist/index.js
@@ -14037,7 +14037,8 @@ async function findSuccessfulCommit(workflow_id, run_id, owner, repo, branch, la
 
 async function findMergeBaseRef() {
   if (eventName == 'merge_group') {
-    return await findMergeQueueBranch(owner, repo, mainBranchName);
+    const mergeQueueBranch = await findMergeQueueBranch(owner, repo, mainBranchName);
+    return `origin/${mergeQueueBranch}`;
   } else {
     return 'HEAD'
   }

--- a/dist/index.js
+++ b/dist/index.js
@@ -14049,8 +14049,11 @@ async function findMergeQueueBranch(owner, repo, mainBranchName) {
   if (!pull_number) {
     throw new Error('Failed to determine PR number')
   }
+  process.stdout.write('\n');
+  process.stdout.write(`Found PR #${pull_number} from merge queue branch\n`);
   const octokit = new Octokit();
   const result = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', { owner, repo, pull_number });
+  process.stdout.write(`Found PR #${pull_number} branch ref: ${result.data.head.ref}\n`);
   return result.data.head.ref;
 }
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -13945,7 +13945,7 @@ let BASE_SHA;
 
   if (['pull_request', 'pull_request_target', 'merge_queue'].includes(eventName) && !github.context.payload.pull_request.merged) {
     try {
-      const mergeBaseRef = findMergeBaseRef();
+      const mergeBaseRef = await findMergeBaseRef();
       const baseResult = spawnSync('git', ['merge-base', `origin/${mainBranchName}`, mergeBaseRef], { encoding: 'utf-8' });
       BASE_SHA = baseResult.stdout;
     } catch (e) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -13946,6 +13946,15 @@ let BASE_SHA;
   if (['pull_request', 'pull_request_target'].includes(eventName) && !github.context.payload.pull_request.merged) {
     const baseResult = spawnSync('git', ['merge-base', `origin/${mainBranchName}`, 'HEAD'], { encoding: 'utf-8' });
     BASE_SHA = baseResult.stdout;
+  } else if (eventName == 'merge_queue' && !github.context.payload.pull_request.merged) {
+    try {
+      const prBranch = await findMergeQueueBranch(owner, repo, mainBranchName);
+      const baseResult = spawnSync('git', ['merge-base', `origin/${prBranch}`, `origin/${mainBranchName}`], { encoding: 'utf-8' });
+      BASE_SHA = baseResult.stdout;
+    } catch (e) {
+      core.setFailed(e.message);
+      return;
+    }
   } else {
     try {
       BASE_SHA = await findSuccessfulCommit(workflowId, runId, owner, repo, mainBranchName, lastSuccessfulEvent);
@@ -14027,6 +14036,22 @@ async function findSuccessfulCommit(workflow_id, run_id, owner, repo, branch, la
   }).then(({ data: { workflow_runs } }) => workflow_runs.map(run => run.head_sha));
 
   return await findExistingCommit(shas);
+}
+
+function findMergeQueuePr(mainBranchName) {
+  const { head_ref, base_sha } = github.context.payload.merge_group;
+  const result = new RegExp(`^refs/heads/gh-readonly-queue/${mainBranchName}/pr-(\\d+)-${base_sha}$`).exec(head_ref);
+  return result ? result.at(1) : undefined;
+}
+
+async function findMergeQueueBranch(owner, repo, mainBranchName) {
+  const pull_number = findMergeQueuePr(mainBranchName);
+  if (!pull_number) {
+    throw new Error('Failed to determine PR number')
+  }
+  const octokit = new Octokit();
+  const result = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', { owner, repo, pull_number });
+  return result.data.head.ref;
 }
 
 /**

--- a/find-successful-workflow.js
+++ b/find-successful-workflow.js
@@ -27,7 +27,7 @@ let BASE_SHA;
   const headResult = spawnSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf-8' });
   const HEAD_SHA = headResult.stdout;
 
-  if (['pull_request', 'pull_request_target', 'merge_queue'].includes(eventName) && !github.context.payload.pull_request.merged) {
+  if (['pull_request', 'pull_request_target', 'merge_group'].includes(eventName) && !github.context.payload.pull_request.merged) {
     try {
       const mergeBaseRef = await findMergeBaseRef();
       const baseResult = spawnSync('git', ['merge-base', `origin/${mainBranchName}`, mergeBaseRef], { encoding: 'utf-8' });
@@ -120,7 +120,7 @@ async function findSuccessfulCommit(workflow_id, run_id, owner, repo, branch, la
 }
 
 async function findMergeBaseRef() {
-  if (eventName == 'merge_queue') {
+  if (eventName == 'merge_group') {
     return await findMergeQueueBranch(owner, repo, mainBranchName);
   } else {
     return 'HEAD'

--- a/find-successful-workflow.js
+++ b/find-successful-workflow.js
@@ -133,8 +133,11 @@ async function findMergeQueueBranch(owner, repo, mainBranchName) {
   if (!pull_number) {
     throw new Error('Failed to determine PR number')
   }
+  process.stdout.write('\n');
+  process.stdout.write(`Found PR #${pull_number} from merge queue branch\n`);
   const octokit = new Octokit();
   const result = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', { owner, repo, pull_number });
+  process.stdout.write(`Found PR #${pull_number} branch ref: ${result.data.head.ref}\n`);
   return result.data.head.ref;
 }
 

--- a/find-successful-workflow.js
+++ b/find-successful-workflow.js
@@ -121,7 +121,8 @@ async function findSuccessfulCommit(workflow_id, run_id, owner, repo, branch, la
 
 async function findMergeBaseRef() {
   if (eventName == 'merge_group') {
-    return await findMergeQueueBranch(owner, repo, mainBranchName);
+    const mergeQueueBranch = await findMergeQueueBranch(owner, repo, mainBranchName);
+    return `origin/${mergeQueueBranch}`;
   } else {
     return 'HEAD'
   }

--- a/find-successful-workflow.js
+++ b/find-successful-workflow.js
@@ -27,13 +27,10 @@ let BASE_SHA;
   const headResult = spawnSync('git', ['rev-parse', 'HEAD'], { encoding: 'utf-8' });
   const HEAD_SHA = headResult.stdout;
 
-  if (['pull_request', 'pull_request_target'].includes(eventName) && !github.context.payload.pull_request.merged) {
-    const baseResult = spawnSync('git', ['merge-base', `origin/${mainBranchName}`, 'HEAD'], { encoding: 'utf-8' });
-    BASE_SHA = baseResult.stdout;
-  } else if (eventName == 'merge_queue' && !github.context.payload.pull_request.merged) {
+  if (['pull_request', 'pull_request_target', 'merge_queue'].includes(eventName) && !github.context.payload.pull_request.merged) {
     try {
-      const prBranch = await findMergeQueueBranch(owner, repo, mainBranchName);
-      const baseResult = spawnSync('git', ['merge-base', `origin/${prBranch}`, `origin/${mainBranchName}`], { encoding: 'utf-8' });
+      const mergeBaseRef = findMergeBaseRef();
+      const baseResult = spawnSync('git', ['merge-base', `origin/${mainBranchName}`, mergeBaseRef], { encoding: 'utf-8' });
       BASE_SHA = baseResult.stdout;
     } catch (e) {
       core.setFailed(e.message);
@@ -122,13 +119,21 @@ async function findSuccessfulCommit(workflow_id, run_id, owner, repo, branch, la
   return await findExistingCommit(shas);
 }
 
-function findMergeQueuePr(mainBranchName) {
+async function findMergeBaseRef() {
+  if (eventName == 'merge_queue') {
+    return await findMergeQueueBranch(owner, repo, mainBranchName);
+  } else {
+    return 'HEAD'
+  }
+}
+
+function findMergeQueuePr() {
   const { head_ref, base_sha } = github.context.payload.merge_group;
   const result = new RegExp(`^refs/heads/gh-readonly-queue/${mainBranchName}/pr-(\\d+)-${base_sha}$`).exec(head_ref);
   return result ? result.at(1) : undefined;
 }
 
-async function findMergeQueueBranch(owner, repo, mainBranchName) {
+async function findMergeQueueBranch() {
   const pull_number = findMergeQueuePr(mainBranchName);
   if (!pull_number) {
     throw new Error('Failed to determine PR number')
@@ -137,7 +142,6 @@ async function findMergeQueueBranch(owner, repo, mainBranchName) {
   process.stdout.write(`Found PR #${pull_number} from merge queue branch\n`);
   const octokit = new Octokit();
   const result = await octokit.request('GET /repos/{owner}/{repo}/pulls/{pull_number}', { owner, repo, pull_number });
-  process.stdout.write(`Found PR #${pull_number} branch ref: ${result.data.head.ref}\n`);
   return result.data.head.ref;
 }
 

--- a/find-successful-workflow.js
+++ b/find-successful-workflow.js
@@ -29,7 +29,7 @@ let BASE_SHA;
 
   if (['pull_request', 'pull_request_target', 'merge_queue'].includes(eventName) && !github.context.payload.pull_request.merged) {
     try {
-      const mergeBaseRef = findMergeBaseRef();
+      const mergeBaseRef = await findMergeBaseRef();
       const baseResult = spawnSync('git', ['merge-base', `origin/${mainBranchName}`, mergeBaseRef], { encoding: 'utf-8' });
       BASE_SHA = baseResult.stdout;
     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "3.1.1",
+  "version": "3.2.0",
   "license": "MIT",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action",
   "scripts": {


### PR DESCRIPTION
Motivation:
nx-set-shas lacks support for github's [merge queues](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#about-merge-queues)

Modification:
- when `eventName === 'merge_group'` and `merge-queue-base-from-pr` input set to `true`, set the `BASE_SHA` to the `merge-base` of the the default branch + PR's branch

Notes / disclaimer:
- extracting the PR's ref is a little brittle at the moment, since the `merge_group` webhook payload does not include it explicitly
  - raised a request to github to include more metadata in the payload: https://github.com/orgs/community/discussions/62219
- using `merge-queue-base-from-pr` on merge queues with the limit set greater than 1 is not recommended (will probably not work as expected).
- did not set up a test for this since it would require merge queues enabled on this repo (if the current testing pattern were to be followed)
