### PR TITLE
Enclose arguments in quotes to ensure position

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
     - name: Set base and head SHAs used for nx affected
       id: setSHAs
       shell: bash
-      run: node $GITHUB_ACTION_PATH/dist/index.js ${{ github.token }} ${{ inputs.main-branch-name }} ${{ inputs.error-on-no-successful-workflow }} ${{ inputs.last-successful-event }} ${{ inputs.working-directory }} ${{ inputs.workflow-id }}
+      run: node $GITHUB_ACTION_PATH/dist/index.js "${{ github.token }}" "${{ inputs.main-branch-name }}" "${{ inputs.error-on-no-successful-workflow }}" "${{ inputs.last-successful-event }}" "${{ inputs.working-directory }}" "${{ inputs.workflow-id }}"
 
     - name: Log base and head SHAs used for nx affected
       shell: bash


### PR DESCRIPTION
In the current implementation, passing a blank value as input may result in unexpected behavior because the arguments are not guaranteed to exist in the specific position. (For example, we can pass empty value to `last-successful-event` for fetching all type of events.)

This commit fixes this issue by enclosing arguments in quotes to ensure that all provided arguments are passed correctly.