### PR TITLE
chore: set version in package.json to match major

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "3.3.2",
+  "version": "4.0.0",
   "license": "MIT",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action",
   "scripts": {


### PR DESCRIPTION
The previous release didn't set the version properly