### PR TITLE
fix: fix commitExists() function for diff bigger than 30 commits

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -38048,6 +38048,7 @@ function commitExists(octokit, branchName, commitSha) {
                 owner,
                 repo,
                 sha: branchName,
+                per_page: 100,
             });
             return commits.data.some((commit) => commit.sha === commitSha);
         }

--- a/find-successful-workflow.ts
+++ b/find-successful-workflow.ts
@@ -259,6 +259,7 @@ async function commitExists(
       owner,
       repo,
       sha: branchName,
+      per_page: 100,
     });
 
     return commits.data.some(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "4.0.3",
+  "version": "4.0.4",
   "license": "MIT",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action",
   "scripts": {


### PR DESCRIPTION
When the diff between NX_BASE & NX_HEAD is bigger than 30 commits the `commitExests` returns false, because it checks only last 30 commits inside the target branch. It happens because `GET /repos/{owner}/{repo}/commits` has default `per_page` value of 30.

In our workflow, a few times a week we have the diff ~50 commits since the last successful run. As the result `nrwl/nx-set-shas` can't find NX_BASE correct and returns `HEAD~1`.

#### Issue screenshot
![image](https://github.com/nrwl/nx-set-shas/assets/11693557/458a652f-1ff1-41de-a839-ee861cac1cce)
