### PR TITLE
chore: branch is available when even is workflow_dispatch

### DIFF
--- a/find-successful-workflow.ts
+++ b/find-successful-workflow.ts
@@ -172,8 +172,8 @@ async function findSuccessfulCommit(
       {
         owner,
         repo,
-        // on non-push workflow runs we do not have branch property
-        branch: lastSuccessfulEvent !== "push" ? undefined : branch,
+        // on some workflow runs we do not have branch property
+        branch: lastSuccessfulEvent === "push" || lastSuccessfulEvent === "workflow_dispatch" ? branch : undefined,
         workflow_id,
         event: lastSuccessfulEvent,
         status: "success",


### PR DESCRIPTION
I'm not entirely sure why you don't always set the branch, especially since the branch can be overridden by the inputs to be always available, meaning the branch would always be set no matter the github event.

But I wanted to play it safe so I only added an exception for `workflow_dispatch` which always runs against a branch and we should always consider the branch in that case because otherwise we would pick from ci run from all branches which is really bad.