### PR TITLE
fix: return correct NX_BASE SHA for merge_group event

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -17,7 +17,7 @@ jobs:
     name: Test workflow integration
     strategy:
       matrix:
-        runs-on: [ubuntu-latest]
+        runs-on: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     uses: ./.github/workflows/integration-test-workflow.yml
     with:

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -17,7 +17,7 @@ jobs:
     name: Test workflow integration
     strategy:
       matrix:
-        runs-on: [ubuntu-latest, macos-latest, windows-latest]
+        runs-on: [ubuntu-latest]
       fail-fast: false
     uses: ./.github/workflows/integration-test-workflow.yml
     with:

--- a/find-successful-workflow.ts
+++ b/find-successful-workflow.ts
@@ -41,23 +41,12 @@ let BASE_SHA: string;
   });
   let HEAD_SHA = headResult.stdout;
 
-  if (
-    (['pull_request', 'pull_request_target'].includes(eventName) &&
-      !github.context.payload.pull_request.merged) ||
-    eventName == 'merge_group'
-  ) {
-    try {
-      const mergeBaseRef = await findMergeBaseRef();
-      const baseResult = spawnSync(
-        'git',
-        ['merge-base', `origin/${mainBranchName}`, mergeBaseRef],
-        { encoding: 'utf-8' },
-      );
-      BASE_SHA = baseResult.stdout;
-    } catch (e) {
-      core.setFailed(e.message);
-      return;
-    }
+  if (['pull_request', 'pull_request_target'].includes(eventName) && !github.context.payload.pull_request.merged) {
+    const baseResult = spawnSync('git', ['merge-base', `origin/${mainBranchName}`, 'HEAD'], { encoding: 'utf-8' });
+    BASE_SHA = baseResult.stdout;
+  } else if (eventName == "merge_group") {
+    const baseResult = spawnSync('git', ['rev-parse', 'HEAD^1'], { encoding: 'utf-8' });
+    BASE_SHA = baseResult.stdout;
   } else {
     try {
       BASE_SHA = await findSuccessfulCommit(
@@ -225,38 +214,6 @@ async function findSuccessfulCommit(
     );
 
   return await findExistingCommit(octokit, branch, shas);
-}
-
-async function findMergeBaseRef(): Promise<string> {
-  if (eventName == 'merge_group') {
-    const mergeQueueBranch = await findMergeQueueBranch();
-    return `origin/${mergeQueueBranch}`;
-  } else {
-    return 'HEAD';
-  }
-}
-
-function findMergeQueuePr(): string {
-  const { head_ref, base_sha } = github.context.payload.merge_group;
-  const result = new RegExp(
-    `^refs/heads/gh-readonly-queue/${mainBranchName}/pr-(\\d+)-${base_sha}$`,
-  ).exec(head_ref);
-  return result ? result.at(1) : undefined;
-}
-
-async function findMergeQueueBranch(): Promise<string> {
-  const pull_number = findMergeQueuePr();
-  if (!pull_number) {
-    throw new Error('Failed to determine PR number');
-  }
-  process.stdout.write('\n');
-  process.stdout.write(`Found PR #${pull_number} from merge queue branch\n`);
-  const octokit = new ProxifiedClient();
-  const result = await octokit.request(
-    `GET /repos/${owner}/${repo}/pulls/${pull_number}`,
-    { owner, repo, pull_number: +pull_number },
-  );
-  return result.data.head.ref;
 }
 
 /**

--- a/find-successful-workflow.ts
+++ b/find-successful-workflow.ts
@@ -41,11 +41,20 @@ let BASE_SHA: string;
   });
   let HEAD_SHA = headResult.stdout;
 
-  if (['pull_request', 'pull_request_target'].includes(eventName) && !github.context.payload.pull_request.merged) {
-    const baseResult = spawnSync('git', ['merge-base', `origin/${mainBranchName}`, 'HEAD'], { encoding: 'utf-8' });
+  if (
+    ['pull_request', 'pull_request_target'].includes(eventName) &&
+    !github.context.payload.pull_request.merged
+  ) {
+    const baseResult = spawnSync(
+      'git',
+      ['merge-base', `origin/${mainBranchName}`, 'HEAD'],
+      { encoding: 'utf-8' },
+    );
     BASE_SHA = baseResult.stdout;
-  } else if (eventName == "merge_group") {
-    const baseResult = spawnSync('git', ['rev-parse', 'HEAD^1'], { encoding: 'utf-8' });
+  } else if (eventName == 'merge_group') {
+    const baseResult = spawnSync('git', ['rev-parse', 'HEAD^1'], {
+      encoding: 'utf-8',
+    });
     BASE_SHA = baseResult.stdout;
   } else {
     try {


### PR DESCRIPTION
**Context**

As reported in #140, the current solution for merge-queue works only when the queue size 1. When more commits are added to the queue, the action keeps setting the same `NX_BASE` for all of them.

**Problem**
When new commits are added to the queue, we expect the `NX_BASE` commit to be the last commit in the queue. However, it sets the last commit in master. _This image from https://github.com/nrwl/nx-set-shas/issues/140#issue-2110155589 represents well the problem._

**Solution proposed**
The `NX_BASE` commit should be main branch HEAD commit when merge-queue has size 1. When size > 1, `NX_BASE` should be the HEAD commit of the last merge branch that current commit is on top of.

Fixes #140