### PR TITLE
Add missing "fallback-sha" to list of arguments

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,7 +48,8 @@ runs:
         last_successful_event: ${{ inputs.last-successful-event }}
         working_directory: ${{ inputs.working-directory }}
         working_id: ${{ inputs.workflow-id }}
-      run: node "$GITHUB_ACTION_PATH/dist/index.js" "$gh_token" "$main_branch_name" "$error_on_no_successful_workflow" "$last_successful_event" "$working_directory" "$working_id"
+        fallback_sha: ${{ inputs.fallback-sha }}
+      run: node "$GITHUB_ACTION_PATH/dist/index.js" "$gh_token" "$main_branch_name" "$error_on_no_successful_workflow" "$last_successful_event" "$working_directory" "$working_id" "$fallback_sha"
 
     - name: Log base and head SHAs used for nx affected
       shell: bash

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "private": true,
-  "version": "4.1.0",
+  "version": "4.1.1",
   "license": "MIT",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action",
   "scripts": {


### PR DESCRIPTION
# Description

The `fallback-sha` is listed as a valid input on the github composite action but never passed (#158) to the javascript running behind the scenes. This PR extracts the `fallback-sha` from the github inputs and passes it to the list of arguments.

**Linked Issues:**

- #166
- #158

> [!IMPORTANT]
> This PR is most likely to be ignored if PR #163 is being merged. 

I tested this update in a private repo and it seems to be working just fine.
<img width="1603" alt="image" src="https://github.com/user-attachments/assets/49ac7fc6-52aa-4fc0-a050-a26956569155">
