### PR TITLE
Allow filtering workflow runs by display name for accurate diffing

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,8 @@ inputs:
     default: '.'
   workflow-id:
     description: 'The ID of the workflow to track or name of the file name. E.g. ci.yml. Defaults to current workflow'
+  filter-display-title:
+    description: 'The filter display title of the workflow run to track. This is used to identify the correct workflow run when multiple runs exist.'
 
 outputs:
   base:

--- a/find-successful-workflow.ts
+++ b/find-successful-workflow.ts
@@ -177,6 +177,7 @@ async function findSuccessfulCommit(
   repo: string,
   branch: string,
   lastSuccessfulEvent: string,
+  filterDisplayTitle: string,
 ): Promise<string | undefined> {
   const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
   if (!workflow_id) {
@@ -211,9 +212,14 @@ async function findSuccessfulCommit(
         status: 'success',
       },
     )
-    .then(({ data: { workflow_runs } }) =>
-      workflow_runs.map((run: { head_sha: any }) => run.head_sha),
-    );
+    .then(({ data: { workflow_runs } }) => {
+      if (!!filterDisplayTitle) {
+        workflow_runs = workflow_runs.filter((workflow_run) =>
+          workflow_run.display_title.includes(filterDisplayTitle),
+        );
+      }
+      return workflow_runs.map((run) => run.head_sha);
+    });
 
   return await findExistingCommit(octokit, branch, shas);
 }

--- a/find-successful-workflow.ts
+++ b/find-successful-workflow.ts
@@ -19,6 +19,7 @@ const workingDirectory = core.getInput('working-directory');
 const workflowId = core.getInput('workflow-id');
 const fallbackSHA = core.getInput('fallback-sha');
 const remote = core.getInput('remote');
+const filterDisplayTitle = core.getInput('filter-display-title');
 const defaultWorkingDirectory = '.';
 
 let BASE_SHA: string;
@@ -67,6 +68,7 @@ let BASE_SHA: string;
         repo,
         mainBranchName,
         lastSuccessfulEvent,
+        filterDisplayTitle,
       );
     } catch (e) {
       core.setFailed(e.message);
@@ -177,7 +179,7 @@ async function findSuccessfulCommit(
   repo: string,
   branch: string,
   lastSuccessfulEvent: string,
-  filterDisplayTitle: string,
+  filterDisplayTitle: string | undefined,
 ): Promise<string | undefined> {
   const octokit = github.getOctokit(process.env.GITHUB_TOKEN);
   if (!workflow_id) {


### PR DESCRIPTION
There are use cases where a single GitHub Actions workflow runs against multiple environments (e.g., dev, stage, prod). Unfortunately, the GitHub API does not expose the inputs values (such as environment) in the workflow run metadata. As a workaround, a common practice is to include inputs.environment in the workflow's display title to make the run context visible.

The Problem:
The current nx-sha logic cannot correctly determine the base and head commits when workflows with the same tag run across different environments.

Current Behavior:
- Run workflow test using dev     | Tag 1.1.0   Current run (head)
- Run workflow test using stage  | Tag 1.1.0   Green          <-- base (wrong)
- Run workflow test using dev     | Tag 1.1.0   Green 

Expected Behavior: 
- Run workflow test using dev     | Tag 1.1.0   Current run (head)
- Run workflow test using stage  | Tag 1.1.0   Green
- Run workflow test using dev     | Tag 1.1.0   Green           <-- base ( correct )

Proposed Solution:
Enhance the action by adding a new input that allows the caller to specify a string pattern (e.g., environment name) that must be present in the workflow display title. This will help the action correctly match workflow runs by context (e.g., only comparing dev runs with other dev runs), and accurately identify the base and head for diffing.