### PR TITLE
Fix: Update merge-group behaviour to support additional merge queue configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,11 @@ jobs:
     # E.g. 'ci.yml'. If not provided, current workflow id will be used
     #
     workflow-id: ''
+
+    # When using merge-group, use the previous commit in the group as the base SHA.
+    #
+    # Default: true
+    use-previous-merge-group-commit: ''
 ```
 
 <!-- end configuration-options -->

--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,9 @@ inputs:
     default: '.'
   workflow-id:
     description: 'The ID of the workflow to track or name of the file name. E.g. ci.yml. Defaults to current workflow'
+  use-previous-merge-group-commit:
+    description: 'When using merge-group, use the previous commit in the group as the base SHA'
+    default: 'true'
 
 outputs:
   base:

--- a/dist/nx-set-shas.js
+++ b/dist/nx-set-shas.js
@@ -22713,6 +22713,7 @@ var workingDirectory = core.getInput("working-directory");
 var workflowId = core.getInput("workflow-id");
 var fallbackSHA = core.getInput("fallback-sha");
 var remote = core.getInput("remote");
+var usePreviousMergeGroupCommit = core.getBooleanInput("use-previous-merge-group-commit");
 var defaultWorkingDirectory = ".";
 var BASE_SHA;
 (async () => {
@@ -22738,7 +22739,7 @@ var BASE_SHA;
       "HEAD"
     ], { encoding: "utf-8" });
     BASE_SHA = baseResult.stdout;
-  } else if (eventName == "merge_group") {
+  } else if (eventName == "merge_group" && usePreviousMergeGroupCommit) {
     const baseResult = spawnSync("git", ["rev-parse", "HEAD^1"], {
       encoding: "utf-8"
     });

--- a/nx-set-shas.ts
+++ b/nx-set-shas.ts
@@ -19,6 +19,9 @@ const workingDirectory = core.getInput('working-directory');
 const workflowId = core.getInput('workflow-id');
 const fallbackSHA = core.getInput('fallback-sha');
 const remote = core.getInput('remote');
+const usePreviousMergeGroupCommit = core.getBooleanInput(
+  'use-previous-merge-group-commit',
+);
 const defaultWorkingDirectory = '.';
 
 let BASE_SHA: string;
@@ -56,7 +59,7 @@ let BASE_SHA: string;
       { encoding: 'utf-8' },
     );
     BASE_SHA = baseResult.stdout;
-  } else if (eventName == 'merge_group') {
+  } else if (eventName == 'merge_group' && usePreviousMergeGroupCommit) {
     const baseResult = spawnSync('git', ['rev-parse', 'HEAD^1'], {
       encoding: 'utf-8',
     });


### PR DESCRIPTION
**Context**
When working with merge queues, one of the configuration options is 'Only merge non-failing pull requests'. As described in the [docs](https://github.com/nrwl/nx-set-shas/issues/140#issuecomment-2701608564), "This setting determines how a merge queue forms groups of pull requests to be merged."

Setting this configuration to *true* means every pull request must pass status checks in order to be merged as part of the group.

Setting this configuration to *false* means that so long as the final pull request in the group passes it's status checks then the whole group will be merged.

**Problem**
Issue: https://github.com/nrwl/nx-set-shas/issues/191
Initial comment: https://github.com/nrwl/nx-set-shas/issues/140#issuecomment-2701608564

The previous change linked above requires 'Only merge non-failing pull requests' to be true. This is fine as failing pull requests will be removed, it can safely assume that the previous commit will be successful.

In cases where 'Only merge non-failing pull requests' is false, it would be preferable for the merge group to use the default previous successful commit behaviour. This would allow the final pull request in a merge group to run the applicable checks for any changes in the group.

**Solution Proposed**
Adding an additional configuration option to make the current merge-group behaviour optional.