### PR TITLE
docs: update actions/checkout to v6 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     name: My Job
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # We need to fetch all branches and commits so that Nx affected has a base to compare against.
           fetch-depth: 0
@@ -161,7 +161,7 @@ jobs:
     container: my-org/my-amazing-image:v1.2.3-fresh
     name: My Job
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # We need to fetch all branches and commits so that Nx affected has a base to compare against.
           fetch-depth: 0


### PR DESCRIPTION
In the v5.0.0 migration to the `node24` runtime and `actions/checkout@v6` in our workflows, I forgot to replace `actions/checkout@v4` with `actions/checkout@v6` in `README.md`.

Bump version to 5.0.2 if necessary (also updates the `v5` tag).